### PR TITLE
Un-cancel when issuing setup request (for real this time)

### DIFF
--- a/src/dragonfly/dragonfly/command.py
+++ b/src/dragonfly/dragonfly/command.py
@@ -283,6 +283,8 @@ class DragonflyCommand:
     def setup_drone(self, request, response):
         print("Setup")
 
+        self.canceled = False
+
         params = ParamSetV2.Request(
             param_id = 'RTL_ALT',
             value = ParameterValue(type = ParameterType.PARAMETER_INTEGER, integer_value = request.rtl_altitude))
@@ -513,10 +515,6 @@ class DragonflyCommand:
         self.node.create_service(type, "/{}/command/{}".format(self.id, name), callback)
 
     def setup(self):
-        self.rtl_boundary = None
-        self.max_altitude = 100
-        self.canceled = False
-
         self.setparam_service = self.create_client_and_wait(ParamSetV2, "/{}/mavros/param/set".format(self.id))
         self.setmode_service = self.create_client_and_wait(SetMode, "/{}/mavros/set_mode".format(self.id))
         self.arm_service = self.create_client_and_wait(CommandBool, "/{}/mavros/cmd/arming".format(self.id))


### PR DESCRIPTION
Ok, setting cancel to `False` in the setup method was incorrect, we should have set it to `False` in the `setup_drone` method.

This PR resets the drone's cancel state when the drone is setup - the setup establishes RTL boundaries and altitude.  Cancel is only triggered once when an RTL boundary is breached allowing the pilot to continue outside the RTL boundary if desired and not have the aircraft fight back into the RTL mode.

To test, comment out [`self.canceled = False` in command.py](https://github.com/BCLab-UNM/dragonfly-controller/blob/master/src/dragonfly/dragonfly/command.py#L437) and [`self.cancel()` in command.py](https://github.com/BCLab-UNM/dragonfly-controller/blob/master/src/dragonfly/dragonfly/command.py#L319) so you can fly missions without the canceled status being toggled. Recompile and test with the following procedure:
1. Setup the RTL boundary
2. Setup mission to takeoff and navigate outside the boundary and RTL
4. Fly the mission, the RTL boundary breach should trigger (not the mission's RTL)
5. Fly the mission again (without setting up the mission) the RTL boundary breach should *not* trigger the RTL (the mission will though)
6. Press Setup to establish the RTL boundary
7. Fly the mission again, the RTL boundary breach should trigger the RTL.
