### PR TITLE
Plume aware lawnmower

### DIFF
--- a/src/dragonfly/dragonfly/actions/PlumeAwareLawnmowerAction.py
+++ b/src/dragonfly/dragonfly/actions/PlumeAwareLawnmowerAction.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+import math
+
+import rx
+import rx.operators as ops
+
+from rx.subject import Subject
+from std_msgs.msg import String
+from .ActionState import ActionState
+
+
+def distance(position1, position2):
+    deltax = position1.x - position2.x
+    deltay = position1.y - position2.y
+    deltaz = position1.z - position2.z
+
+    return math.sqrt((deltax * deltax) + (deltay * deltay) + (deltaz * deltaz))
+
+
+class PlumeAwareLawnmowerAction:
+    STOP_VELOCITY_THRESHOLD = 0.1
+    SAMPLE_RATE = 0.1
+    WAIT_FOR_WAYPOINT = 10
+    WAYPOINT_ACCEPTANCE_ADJUSTMENT = {'x': 0, 'y': 0, 'z': 0}
+
+    def __init__(self, id, logPublisher, local_setposition_publisher, waypoints, distance_threshold, step_length, boundary_length, local_velocity_observable, local_pose_observable, co2_observable):
+        self.id = id
+        self.logPublisher = logPublisher
+        self.waypoints = waypoints
+        self.distance_threshold = distance_threshold
+        self.local_setposition_publisher = local_setposition_publisher
+        self.status = ActionState.WORKING
+        self.commanded = False
+        self.position_update = None
+        self.velocity_update = None
+        self.velocity_subject = Subject()
+        self.pose_subject = Subject()
+        self.waypointAcceptanceSubscription = rx.empty().subscribe()
+        self.local_velocity_observable = local_velocity_observable
+        self.local_pose_observable = local_pose_observable
+        self.co2_observable = co2_observable
+        self.step_length = step_length
+        self.boundary_length = boundary_length
+
+        self.current_waypoint_index = 0
+        self.current_waypoint = self.waypoints[0]
+        self.above_ambient_last = None
+        self.ambient_threshold = 425
+        self.status = ActionState.WORKING
+
+    def step(self):
+        if self.current_waypoint_index < len(self.waypoints) :
+            if not self.commanded:
+                self.commanded = True
+
+                def updatePosition(pose, ppm):
+                    if self.current_waypoint_index > self.boundary_length:
+                        if ppm > self.ambient_threshold:
+                            self.above_ambient_last = pose
+
+                        if self.above_ambient_last and distance(pose, self.above_ambient_last) > self.step_length:
+                            # Turn, below ambient
+                            if self.current_waypoint_index < len(self.waypoints) - 1:
+                                # Skip the next waypoint
+                                self.current_waypoint_index = self.current_waypoint_index + 1
+                                self.current_waypoint = self.waypoints[self.current_waypoint_index]
+                                self.current_waypoint.pose.position.x = pose.x
+                                self.local_setposition_publisher.publish(self.current_waypoint)
+                                self.logPublisher.publish(String(data="Exited plume, pruning..."))
+                            self.above_ambient_last = None
+
+                    if distance(self.current_waypoint.pose.position, pose) < self.distance_threshold:
+                        if self.current_waypoint_index < len(self.waypoints) - 1:
+                            self.current_waypoint_index = self.current_waypoint_index + 1
+                            self.current_waypoint = self.waypoints[self.current_waypoint_index]
+                            self.local_setposition_publisher.publish(self.current_waypoint)
+                            self.logPublisher.publish(String(data="Goto {} {}/{}".format(
+                                "Lawnmower",
+                                self.current_waypoint_index + 1,
+                                len(self.waypoints))))
+                        else:
+                            self.status = ActionState.SUCCESS
+                            self.stop()
+
+                self.waypointAcceptanceSubscription = rx.combine_latest(self.local_pose_observable, self.co2_observable).pipe(
+                    ops.sample(self.SAMPLE_RATE)
+                ).subscribe(on_next=lambda values: updatePosition(values[0].pose.position, values[1].ppm))
+
+                self.local_setposition_publisher.publish(self.current_waypoint)
+        return self.status
+
+    def stop(self):
+        print("Called stop")
+        self.waypointAcceptanceSubscription.dispose()

--- a/src/dragonfly/dragonfly/actions/__init__.py
+++ b/src/dragonfly/dragonfly/actions/__init__.py
@@ -19,4 +19,5 @@ from .TakeoffAction import TakeoffAction
 from .WaitForDisarmAction import WaitForDisarmAction
 from .WaitForZeroAction import WaitForZeroAction
 from .WaypointAction import WaypointAction
+from .PlumeAwareLawnmowerAction import PlumeAwareLawnmowerAction
 from std_msgs.msg import String

--- a/src/dragonfly/dragonfly/command.py
+++ b/src/dragonfly/dragonfly/command.py
@@ -391,8 +391,15 @@ class DragonflyCommand:
                                                                step.lawnmower_step.walk, step.lawnmower_step.altitude,
                                                                step.lawnmower_step.stacks, step.lawnmower_step.step_length,
                                                                self.orientation)
-                    self.runWaypoints("Lawnmower", waypoints, step.lawnmower_step.wait_time,
-                                      step.lawnmower_step.distance_threshold)
+                    boundary_length = len(boundary) if step.lawnmower_step.walk_boundary else 0
+                    self.runPlumeAwareWaypoints("Lawnmower",
+                                                waypoints,
+                                                step.lawnmower_step.wait_time,
+                                                step.lawnmower_step.step_length,
+                                                boundary_length,
+                                                step.lawnmower_step.distance_threshold)
+                    # self.runWaypoints("Lawnmower", waypoints, step.lawnmower_step.wait_time,
+                    #                   step.lawnmower_step.distance_threshold)
             elif step.msg_type == MissionStep.TYPE_NAVIGATION:
                 print("Navigation")
                 self.actionqueue.push(LogAction(self.logPublisher, "Navigation"))
@@ -454,6 +461,11 @@ class DragonflyCommand:
             self.actionqueue.push(WaitForZeroAction(self.logPublisher, self))
 
         return
+
+    def runPlumeAwareWaypoints(self, waypoints_name, waypoints, wait_time, step_length, boundary_length, distance_threshold):
+        self.actionqueue.push(PlumeAwareLawnmowerAction(self.id, self.logPublisher, self.local_setposition_publisher, waypoints,
+                                                  distance_threshold, step_length, boundary_length, self.local_velocity_observable, self.local_position_observable,
+                                                        self.drone_stream_factory.get_drone(self.id).get_co2()))
 
     def flock(self, request, response):
         flockCommand = request.steps[0]  # @TODO: check if this is right

--- a/src/dragonfly/dragonfly/command.py
+++ b/src/dragonfly/dragonfly/command.py
@@ -464,7 +464,7 @@ class DragonflyCommand:
 
     def runPlumeAwareWaypoints(self, waypoints_name, waypoints, wait_time, step_length, boundary_length, distance_threshold):
         self.actionqueue.push(PlumeAwareLawnmowerAction(self.id, self.logPublisher, self.local_setposition_publisher, waypoints,
-                                                  distance_threshold, step_length, boundary_length, self.local_velocity_observable, self.local_position_observable,
+                                                  distance_threshold, step_length, boundary_length, self.local_position_observable,
                                                         self.drone_stream_factory.get_drone(self.id).get_co2()))
 
     def flock(self, request, response):


### PR DESCRIPTION
Runs the lawnmower waypoints, but if an exit of the plume is detected on a pass, reroutes the drones to the next pass at the given longitude.

To test: run the following mission file against the virtual plume in balloon fiesta park:
https://drive.google.com/file/d/13nJcgrNf4J4zksqLlNaSZMX-mZvpwUkg/view?usp=sharing
NOTE: Updated this link as it was previously the wrong test mission.

Note, I made the co2 threshold static for now.  I figure we'll make this a user input in another effort.