### PR TITLE
Fixes sensor average_temp attribute

### DIFF
--- a/src/dragonfly/dragonfly/co2publisher.py
+++ b/src/dragonfly/dragonfly/co2publisher.py
@@ -45,7 +45,7 @@ class CO2Publisher:
     elif sba5_data[0].startswith('W') and len(sba5_data) == 1:
       # W,43.1
       reading = CO2(warming=True,
-          sensor_temp=float(sba5_data[1]))
+          average_temp=float(sba5_data[1]))
     else:
       self.logger.error(f"Unable to parse SBA-5 message: {sba5_str}")
 

--- a/src/dragonfly/dragonfly/logger.py
+++ b/src/dragonfly/dragonfly/logger.py
@@ -63,7 +63,7 @@ class co2Logger:
         if self.position is not None:
             print("{} co2: {} {} {} {} {} {} {} {} @ {} {} {}".format(self.getDate(),
                                                                       data.ppm,
-                                                                      data.sensor_temp,
+                                                                      data.average_temp,
                                                                       data.humidity,
                                                                       data.humidity_sensor_temp,
                                                                       data.atmospheric_pressure,
@@ -76,7 +76,7 @@ class co2Logger:
         else:
             print("{} co2: {} {} {} {} {} {} {} {} @ -".format(self.getDate(),
                                                                data.ppm,
-                                                               data.sensor_temp,
+                                                               data.average_temp,
                                                                data.humidity,
                                                                data.humidity_sensor_temp,
                                                                data.atmospheric_pressure,


### PR DESCRIPTION
`co2.sensor_temp` was renamed to `average_temp`, and we missed it in the logger.  Oops.  This PR fixes it.  The symptom was the LED wasn't turning green if CO2 was given (i.e. virtual plume signal was available).  With this PR, the LED lights up and the logger outputs the appropriate values.