### PR TITLE
docker/Dockerfile:fixSetuptools version remove SetuptoolsDeprecationWarn

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,6 +12,10 @@ RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 
 RUN pip install pulp rx scikit-learn
 
+# Fix the setuptools version to remove the "SetuptoolsDeprecationWarning: setup.py install is deprecated. \
+# Use build and pip and other standards-based tools." Warning print out
+RUN pip install setuptools==58.2.0
+
 # Clear apt cache to save on space
 RUN rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Instead of rewriting the whole package and all the imports everywhere(I was 9 commits deep and had 33 files with changes and decided this would be easier insted) for now just fix the setuptools version to remove the 
> SetuptoolsDeprecationWarning: setup.py install is deprecated.  Use build and pip and other standards-based tools.
Warning print out

Also for anyone building locally and wants to get rid of the warning they should run `pip install setuptools==58.2.0`
If they have an env. setup do it inside that. 